### PR TITLE
feat: 状態管理システムの実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
+import { AppProvider } from './context/AppContext';
 import { HomePage } from './pages/HomePage';
 import './App.css';
 
 function App() {
   return (
-    <div className="App">
-      <HomePage />
-    </div>
+    <AppProvider>
+      <div className="App">
+        <HomePage />
+      </div>
+    </AppProvider>
   );
 }
 

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,0 +1,88 @@
+import React, { createContext, useContext, useReducer } from 'react';
+import type { ReactNode } from 'react';
+import type { AppState, AppAction } from '../types';
+import { appReducer, initialState } from './appReducer';
+
+// Context の型定義
+interface AppContextType {
+  state: AppState;
+  dispatch: React.Dispatch<AppAction>;
+}
+
+// Context の作成
+const AppContext = createContext<AppContextType | undefined>(undefined);
+
+// Provider コンポーネントの Props 型
+interface AppProviderProps {
+  children: ReactNode;
+}
+
+// Provider コンポーネント
+export function AppProvider({ children }: AppProviderProps) {
+  const [state, dispatch] = useReducer(appReducer, initialState);
+
+  const value = {
+    state,
+    dispatch,
+  };
+
+  return (
+    <AppContext.Provider value={value}>
+      {children}
+    </AppContext.Provider>
+  );
+}
+
+// Context を使用するためのカスタムフック
+export function useAppContext() {
+  const context = useContext(AppContext);
+  
+  if (context === undefined) {
+    throw new Error('useAppContext must be used within an AppProvider');
+  }
+  
+  return context;
+}
+
+// アクションクリエーター（オプション：使いやすさのため）
+export const actions = {
+  setLoading: (loading: boolean): AppAction => ({
+    type: 'SET_LOADING',
+    payload: loading,
+  }),
+
+  setError: (error: string | null): AppAction => ({
+    type: 'SET_ERROR',
+    payload: error,
+  }),
+
+  setCurrentImage: (image: AppState['currentImage']): AppAction => ({
+    type: 'SET_CURRENT_IMAGE',
+    payload: image,
+  }),
+
+  setBreeds: (breeds: string[]): AppAction => ({
+    type: 'SET_BREEDS',
+    payload: breeds,
+  }),
+
+  setSelectedBreed: (breed: string | null): AppAction => ({
+    type: 'SET_SELECTED_BREED',
+    payload: breed,
+  }),
+
+  addToFavorites: (image: AppState['favorites'][0]): AppAction => ({
+    type: 'ADD_TO_FAVORITES',
+    payload: image,
+  }),
+
+  removeFromFavorites: (imageId: string): AppAction => ({
+    type: 'REMOVE_FROM_FAVORITES',
+    payload: imageId,
+  }),
+
+  setFavorites: (favorites: AppState['favorites']): AppAction => ({
+    type: 'SET_FAVORITES',
+    payload: favorites,
+  }),
+};

--- a/src/context/appReducer.ts
+++ b/src/context/appReducer.ts
@@ -1,0 +1,79 @@
+import type { AppState, AppAction } from '../types';
+
+// 初期状態
+export const initialState: AppState = {
+  currentImage: null,
+  breeds: [],
+  selectedBreed: null,
+  favorites: [],
+  loading: false,
+  error: null,
+};
+
+// リデューサー関数
+export function appReducer(state: AppState, action: AppAction): AppState {
+  switch (action.type) {
+    case 'SET_LOADING':
+      return {
+        ...state,
+        loading: action.payload,
+        error: action.payload ? null : state.error, // ローディング開始時はエラーをクリア
+      };
+
+    case 'SET_ERROR':
+      return {
+        ...state,
+        error: action.payload,
+        loading: false, // エラー発生時はローディングを停止
+      };
+
+    case 'SET_CURRENT_IMAGE':
+      return {
+        ...state,
+        currentImage: action.payload,
+        loading: false,
+        error: null,
+      };
+
+    case 'SET_BREEDS':
+      return {
+        ...state,
+        breeds: action.payload,
+        loading: false,
+        error: null,
+      };
+
+    case 'SET_SELECTED_BREED':
+      return {
+        ...state,
+        selectedBreed: action.payload,
+      };
+
+    case 'ADD_TO_FAVORITES':
+      // 重複チェック
+      const existingFavorite = state.favorites.find(fav => fav.id === action.payload.id);
+      if (existingFavorite) {
+        return state; // 既に存在する場合は何もしない
+      }
+      
+      return {
+        ...state,
+        favorites: [...state.favorites, action.payload],
+      };
+
+    case 'REMOVE_FROM_FAVORITES':
+      return {
+        ...state,
+        favorites: state.favorites.filter(fav => fav.id !== action.payload),
+      };
+
+    case 'SET_FAVORITES':
+      return {
+        ...state,
+        favorites: action.payload,
+      };
+
+    default:
+      return state;
+  }
+}

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -1,0 +1,66 @@
+import { useAppContext, actions } from '../context/AppContext';
+import type { DogImage } from '../types';
+
+/**
+ * アプリケーション状態を管理するためのカスタムフック
+ * Context API と useReducer を使用した状態管理の便利なインターフェースを提供
+ */
+export function useAppState() {
+  const { state, dispatch } = useAppContext();
+
+  // 状態更新のヘルパー関数
+  const setLoading = (loading: boolean) => {
+    dispatch(actions.setLoading(loading));
+  };
+
+  const setError = (error: string | null) => {
+    dispatch(actions.setError(error));
+  };
+
+  const setCurrentImage = (image: DogImage | null) => {
+    dispatch(actions.setCurrentImage(image));
+  };
+
+  const setBreeds = (breeds: string[]) => {
+    dispatch(actions.setBreeds(breeds));
+  };
+
+  const setSelectedBreed = (breed: string | null) => {
+    dispatch(actions.setSelectedBreed(breed));
+  };
+
+  const addToFavorites = (image: DogImage) => {
+    dispatch(actions.addToFavorites(image));
+  };
+
+  const removeFromFavorites = (imageId: string) => {
+    dispatch(actions.removeFromFavorites(imageId));
+  };
+
+  const setFavorites = (favorites: DogImage[]) => {
+    dispatch(actions.setFavorites(favorites));
+  };
+
+  // お気に入りチェック用のヘルパー関数
+  const isFavorite = (imageId: string): boolean => {
+    return state.favorites.some(fav => fav.id === imageId);
+  };
+
+  return {
+    // 状態
+    ...state,
+    
+    // アクション
+    setLoading,
+    setError,
+    setCurrentImage,
+    setBreeds,
+    setSelectedBreed,
+    addToFavorites,
+    removeFromFavorites,
+    setFavorites,
+    
+    // ヘルパー
+    isFavorite,
+  };
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,26 +1,58 @@
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 import { BreedList } from '../components/BreedList';
 import { BreedDetail } from '../components/BreedDetail';
 import { useDogBreeds } from '../hooks/useDogBreeds';
+import { useAppState } from '../hooks/useAppState';
 import type { DogBreed } from '../types';
 
 export const HomePage: React.FC = () => {
   const { breeds, loading, error } = useDogBreeds();
-  const [selectedBreed, setSelectedBreed] = useState<DogBreed | null>(null);
+  const { 
+    selectedBreed, 
+    setSelectedBreed,
+    setBreeds,
+    setLoading,
+    setError 
+  } = useAppState();
+
+  // 犬種データをグローバル状態に同期
+  useEffect(() => {
+    if (breeds.length > 0) {
+      // DogBreed[]からstring[]に変換
+      const breedNames = breeds.map(breed => breed.name);
+      setBreeds(breedNames);
+    }
+  }, [breeds, setBreeds]);
+
+  // ローディング状態をグローバル状態に同期
+  useEffect(() => {
+    setLoading(loading);
+  }, [loading, setLoading]);
+
+  // エラー状態をグローバル状態に同期
+  useEffect(() => {
+    setError(error);
+  }, [error, setError]);
 
   const handleBreedSelect = (breed: DogBreed) => {
-    setSelectedBreed(breed);
+    // DogBreed型からstring型に変換してグローバル状態に保存
+    setSelectedBreed(breed.name);
   };
 
   const handleBack = () => {
     setSelectedBreed(null);
   };
 
+  // selectedBreedがstring型なので、DogBreed型に変換
+  const selectedBreedObj = selectedBreed 
+    ? breeds.find(breed => breed.name === selectedBreed) || null
+    : null;
+
   return (
     <div style={{ padding: '20px' }}>
       <h1>犬種図鑑</h1>
-      {selectedBreed ? (
-        <BreedDetail breed={selectedBreed} onBack={handleBack} />
+      {selectedBreedObj ? (
+        <BreedDetail breed={selectedBreedObj} onBack={handleBack} />
       ) : (
         <BreedList
           breeds={breeds}


### PR DESCRIPTION
- Context APIとuseReducerを使用したグローバル状態管理を実装
- appReducer.tsで状態遷移ロジックを定義
- AppContext.tsxでContext APIとプロバイダーを実装
- useAppState.tsで使いやすいカスタムフックを提供
- App.tsxにAppProviderを統合
- HomePage.tsxをグローバル状態管理に対応

要件: 1.1, 2.1, 3.1